### PR TITLE
[IMP] Export logic of report fields, export date format, default field values

### DIFF
--- a/stock_outgoing_shipment_report/controllers/main.py
+++ b/stock_outgoing_shipment_report/controllers/main.py
@@ -3,6 +3,7 @@
 
 import json
 from odoo.addons.web.controllers.main import CSVExport
+from odoo.addons.web.controllers.main import ExcelExport
 
 
 class CSVExportInherit(CSVExport):
@@ -18,3 +19,18 @@ class CSVExportInherit(CSVExport):
             params['fields'].pop(0)
             data = json.dumps(params)
         return super(CSVExportInherit, self).base(data, token)
+
+
+class ExcelExportInherit(ExcelExport):
+
+    # Override the base() method which is used to gather fields' values in the
+    # export Excel.
+    def base(self, data, token):
+        params = json.loads(data)
+        # When the stock.outgoing.shipment.report model is selected, remove
+        # the first element in the fields list which is the External ID by
+        # default.
+        if params['model'] == 'stock.outgoing.shipment.report':
+            params['fields'].pop(0)
+            data = json.dumps(params)
+        return super(ExcelExportInherit, self).base(data, token)

--- a/stock_outgoing_shipment_report/models/delivery_carrier_service.py
+++ b/stock_outgoing_shipment_report/models/delivery_carrier_service.py
@@ -30,6 +30,9 @@ class DeliveryCarrierService(models.Model):
         string='MOS',
         required=True,
     )
+    ship_to_residential_indicator = fields.Boolean(
+        string='ShipToResidentialIndicator',
+    )
 
     def name_get(self):
         res = []

--- a/stock_outgoing_shipment_report/models/product_template.py
+++ b/stock_outgoing_shipment_report/models/product_template.py
@@ -1,7 +1,8 @@
 # Copyright 2019 Quartile Limited
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import models, fields, api
+from odoo import models, fields, api, _
+from odoo.exceptions import ValidationError
 
 
 class ProductTemplate(models.Model):
@@ -10,3 +11,11 @@ class ProductTemplate(models.Model):
     delivery_report_desc = fields.Char(
         string='Description (Delivery Report)',
     )
+
+    @api.constrains('delivery_report_desc')
+    def _validate_delivery_report_desc(self):
+        for rec in self:
+            msg = _("%s should be at most %s digit(s).")
+            if rec.delivery_report_desc and len(rec.delivery_report_desc) > 40:
+                raise ValidationError(
+                    msg % (_("Description (Delivery Report)"), "40"))

--- a/stock_outgoing_shipment_report/models/sale_order.py
+++ b/stock_outgoing_shipment_report/models/sale_order.py
@@ -14,3 +14,15 @@ class SaleOrder(models.Model):
         'delivery.carrier.service',
         string='Delivery Service',
     )
+    shipping_use_carrier_acct = fields.Char(
+        string='Delivery Carrier Account Number',
+    )
+
+    @api.onchange('carrier_id')
+    def _onchange_carrier_id(self):
+        if self.carrier_id and self.partner_shipping_id.delivery_carrier_account_ids.filtered(
+                lambda l: l.carrier_id == self.carrier_id):
+            self.shipping_use_carrier_acct = self.partner_shipping_id.delivery_carrier_account_ids.filtered(
+                lambda l: l.carrier_id == self.carrier_id).delivery_carrier_account_num
+        else:
+            self.shipping_use_carrier_acct = False

--- a/stock_outgoing_shipment_report/models/stock_picking.py
+++ b/stock_outgoing_shipment_report/models/stock_picking.py
@@ -1,7 +1,7 @@
 # Copyright 2019 Quartile Limited
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import models, fields, api, _
+from odoo import models, fields, api
 
 
 class StockPicking(models.Model):
@@ -12,7 +12,22 @@ class StockPicking(models.Model):
         moves = self.mapped('move_lines')
         self._cr.execute("DELETE FROM stock_outgoing_shipment_report")
         for move in moves:
-            self.env['stock.outgoing.shipment.report'].create({
-                'move_id': move.id
-            })
+            vals = {
+                'move_id': move.id,
+                'carrier_id': move.sale_line_id and move.sale_line_id.order_id.carrier_id and move.sale_line_id.order_id.carrier_id.id or False,
+                'po_date_edit': move.sale_line_id and move.sale_line_id.order_id.date_order or False,
+                'shipping_carrier': move.sale_line_id and move.sale_line_id.order_id.carrier_id and move.sale_line_id.order_id.carrier_id.name or False,
+                'shipping_insurance_amount': move.sale_line_id and move.sale_line_id.order_id.shipping_insurance_amt and str(move.sale_line_id.order_id.shipping_insurance_amt) or False,
+                'ship_to_first_name': move.picking_partner_id.name[:30] if move.picking_partner_id and len(move.picking_partner_id.name) > 30 else move.picking_partner_id and move.picking_partner_id.name or False,
+                'ship_to_company': move.picking_partner_id.parent_id.name[:30] if move.picking_partner_id and move.picking_partner_id.parent_id and len(move.picking_partner_id.parent_id.name) > 30 else move.picking_partner_id and move.picking_partner_id.parent_id and move.picking_partner_id.parent_id.name or False,
+                'ship_to_address1': move.picking_partner_id.street[:30] if move.picking_partner_id and len(move.picking_partner_id.street or '') > 30 else move.picking_partner_id and move.picking_partner_id.street or False,
+                'ship_to_address2': move.picking_partner_id.street2[:30] if move.picking_partner_id and len(move.picking_partner_id.street2 or '') > 30 else move.picking_partner_id and move.picking_partner_id.street2 or False,
+                'ship_to_city': move.picking_partner_id.city[:30] if move.picking_partner_id and len(move.picking_partner_id.city or '') > 30 else move.picking_partner_id and move.picking_partner_id.city or False,
+                'ship_to_state': move.picking_partner_id and move.picking_partner_id.state_id and move.picking_partner_id.state_id.code or False,
+                'ship_to_country_code': move.picking_partner_id and move.picking_partner_id.country_id and move.picking_partner_id.country_id.code or False,
+                'ship_to_zip': move.picking_partner_id and move.picking_partner_id.zip or False,
+                'ship_to_phone': move.picking_partner_id and move.picking_partner_id.phone or False,
+                'description': move.product_id.product_tmpl_id.delivery_report_desc or move.product_id.name[:40] if len(move.product_id.name) > 40 else move.product_id.name,
+            }
+            self.env['stock.outgoing.shipment.report'].create(vals)
         return self.env.ref('stock_outgoing_shipment_report.action_stock_outgoing_shipment_report').read()[0]

--- a/stock_outgoing_shipment_report/views/delivery_carrier_service_views.xml
+++ b/stock_outgoing_shipment_report/views/delivery_carrier_service_views.xml
@@ -9,6 +9,7 @@
                 <field name="carrier_id"/>
                 <field name="name"/>
                 <field name="description"/>
+                <field name="ship_to_residential_indicator"/>
                 <field name="mos"/>
             </tree>
         </field>

--- a/stock_outgoing_shipment_report/views/sale_order_views.xml
+++ b/stock_outgoing_shipment_report/views/sale_order_views.xml
@@ -8,6 +8,7 @@
         <field name="arch" type="xml">
             <xpath expr="//div[@name='carrier_selection']" position="after">
                 <field name="delivery_carrier_service_id" domain="[('carrier_id', '=', carrier_id)]"/>
+                <field name="shipping_use_carrier_acct"/>
                 <field name="shipping_insurance_amt"/>
             </xpath>
         </field>

--- a/stock_outgoing_shipment_report/views/stock_outgoing_shipment_report_views.xml
+++ b/stock_outgoing_shipment_report/views/stock_outgoing_shipment_report_views.xml
@@ -8,9 +8,12 @@
             <tree string="Stock Outgoing Shipment Report" editable="top">
                 <field name="customer_order_no"/>
                 <field name="po_number"/>
-                <field name="po_date" widget="date"/>
-                <field name="ship_date" widget="date"/>
-                <field name="ship_no_later" widget="date"/>
+                <field name="po_date" invisible="1"/>
+                <field name="po_date_edit" widget="date" string='PODate'/>
+                <field name="ship_date" invisible="1"/>
+                <field name="ship_date_edit" widget="date" string="ShipDate"/>
+                <field name="ship_no_later" invisible="1"/>
+                <field name="ship_no_later_edit" widget="date" string="ShipNoLater"/>
                 <field name="shipping_carrier"/>
                 <field name="shipping_service"/>
                 <field name="shipping_signature_requred"/>


### PR DESCRIPTION
- Remove 'External ID' from ExcelExport
- Add 'ShipToResidentialIndicator' to Delivery Service and related logic to report
- Add validation to 'delivery_report_desc' in product
- Adjust export logic, avoid using related fields in editable fields
- Remove 'N' options from selection fields that requires empty value in export files
- Adjust date fields, separate input fields and export fields