### PR TITLE
rename additional_info to sale_additional_info on res.partner

### DIFF
--- a/sale_order_additional_info/__manifest__.py
+++ b/sale_order_additional_info/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Sales Order Additional Information",
     "summary": "",
-    "version": "12.0.1.0.0",
+    "version": "12.0.1.0.1",
     "category": "Sales",
     "website": "https://www.quartile.co/",
     "author": "Quartile Limited",

--- a/sale_order_additional_info/i18n/ja.po
+++ b/sale_order_additional_info/i18n/ja.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-05-21 09:52+0000\n"
-"PO-Revision-Date: 2019-05-21 09:52+0000\n"
+"POT-Creation-Date: 2019-11-08 06:21+0000\n"
+"PO-Revision-Date: 2019-11-08 06:21+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,7 +16,8 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: sale_order_additional_info
-#: model:ir.model.fields,field_description:sale_order_additional_info.field_res_partner__additional_info
+#: model:ir.model.fields,field_description:sale_order_additional_info.field_res_partner__sale_additional_info
+#: model:ir.model.fields,field_description:sale_order_additional_info.field_res_users__sale_additional_info
 #: model:ir.model.fields,field_description:sale_order_additional_info.field_sale_order__additional_info
 #: model_terms:ir.ui.view,arch_db:sale_order_additional_info.sale_order_portal_content
 msgid "Additional Information"
@@ -28,7 +29,18 @@ msgid "Additional Information:"
 msgstr "追加情報:"
 
 #. module: sale_order_additional_info
-#: model:ir.model.fields,help:sale_order_additional_info.field_res_partner__additional_info
+#: model:ir.model,name:sale_order_additional_info.model_res_partner
+msgid "Contact"
+msgstr "連絡先"
+
+#. module: sale_order_additional_info
+#: model:ir.model,name:sale_order_additional_info.model_sale_order
+msgid "Sale Order"
+msgstr ""
+
+#. module: sale_order_additional_info
+#: model:ir.model.fields,help:sale_order_additional_info.field_res_partner__sale_additional_info
+#: model:ir.model.fields,help:sale_order_additional_info.field_res_users__sale_additional_info
 msgid "This field will be proposed to sales order."
 msgstr "この項目が販売見積に提案されます。"
 

--- a/sale_order_additional_info/i18n/ja.po
+++ b/sale_order_additional_info/i18n/ja.po
@@ -36,11 +36,10 @@ msgstr "連絡先"
 #. module: sale_order_additional_info
 #: model:ir.model,name:sale_order_additional_info.model_sale_order
 msgid "Sale Order"
-msgstr ""
+msgstr "販売オーダ"
 
 #. module: sale_order_additional_info
 #: model:ir.model.fields,help:sale_order_additional_info.field_res_partner__sale_additional_info
 #: model:ir.model.fields,help:sale_order_additional_info.field_res_users__sale_additional_info
 msgid "This field will be proposed to sales order."
-msgstr "この項目が販売見積に提案されます。"
-
+msgstr "この項目の値は販売オーダに提案されます。"

--- a/sale_order_additional_info/models/res_partner.py
+++ b/sale_order_additional_info/models/res_partner.py
@@ -7,8 +7,9 @@ from odoo import models, fields, api
 class ResPartner(models.Model):
     _inherit = 'res.partner'
 
-    additional_info = fields.Char(
+    sale_additional_info = fields.Char(
         string='Additional Information',
         help='This field will be proposed to sales order.',
+        oldname="additional_info",
         copy=False,
     )

--- a/sale_order_additional_info/models/sale_order.py
+++ b/sale_order_additional_info/models/sale_order.py
@@ -14,4 +14,4 @@ class SaleOrder(models.Model):
     @api.onchange('partner_id')
     def _onchange_partner_id(self):
         if self.partner_id:
-            self.additional_info = self.partner_id.additional_info
+            self.additional_info = self.partner_id.sale_additional_info

--- a/sale_order_additional_info/views/res_partner_views.xml
+++ b/sale_order_additional_info/views/res_partner_views.xml
@@ -7,7 +7,7 @@
         <field name="inherit_id" ref="base.view_partner_form"/>
         <field name="arch" type="xml">
             <xpath expr="//group[@name='sale']" position="inside">
-                <field name="additional_info"/>
+                <field name="sale_additional_info"/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
There are few steps I want to confirm when renaming the field’s name of the model without an errors:
	1. Go to the module on UI for a ready to be upgrade
	2. Start working on your code for renaming with attri “oldname”. Restart server
	3. Go to step 1 and upgrade the module, then everything will fine.
Note: Make sure you are not on the Odoo UI 's form of the model you are about to rename.