### PR TITLE
st2 [1779][IMP] stock_outgoing_shipment_report

### DIFF
--- a/stock_outgoing_shipment_report/__manifest__.py
+++ b/stock_outgoing_shipment_report/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Stock Outgoing Shipment Report",
     "summary": "",
-    "version": "12.0.1.1.0",
+    "version": "12.0.1.1.1",
     "category": "Stock",
     "website": "https://www.quartile.co/",
     "author": "Quartile Limited",

--- a/stock_outgoing_shipment_report/models/delivery_carrier.py
+++ b/stock_outgoing_shipment_report/models/delivery_carrier.py
@@ -12,3 +12,8 @@ class DeliveryCarrier(models.Model):
         inverse_name="carrier_id",
         string="Available Service(s)",
     )
+
+    ship_billing = fields.Selection(
+        [("third_party", "Third Party"), ("bill_third_party", "Bill Third Party")],
+        string="Ship Billing"
+    )

--- a/stock_outgoing_shipment_report/models/delivery_carrier.py
+++ b/stock_outgoing_shipment_report/models/delivery_carrier.py
@@ -15,5 +15,5 @@ class DeliveryCarrier(models.Model):
 
     ship_billing = fields.Selection(
         [("third_party", "Third Party"), ("bill_third_party", "Bill Third Party")],
-        string="Ship Billing"
+        string="Ship Billing",
     )

--- a/stock_outgoing_shipment_report/models/delivery_carrier.py
+++ b/stock_outgoing_shipment_report/models/delivery_carrier.py
@@ -13,7 +13,8 @@ class DeliveryCarrier(models.Model):
         string="Available Service(s)",
     )
 
-    ship_billing = fields.Selection(
-        [("third_party", "Third Party"), ("bill_third_party", "Bill Third Party")],
+    ship_billing = fields.Char(
+        help="The value set here will show as"
+        "ShipBilling in the outgoing shipment report.",
         string="Ship Billing",
     )

--- a/stock_outgoing_shipment_report/models/stock_picking.py
+++ b/stock_outgoing_shipment_report/models/stock_picking.py
@@ -18,12 +18,14 @@ class StockPicking(models.Model):
             product = move.product_id
             vals = {"move_id": move.id}
             if order:
-                carrier = order.carrier_id
+                carrier = self.carrier_id
                 vals["carrier_id"] = carrier.id if carrier else False
                 vals["ship_service_id"] = (
                     order.delivery_carrier_service_id
                     and order.delivery_carrier_service_id.id
                 )
+                vals["ship_carrier"] = carrier.name
+                vals["ship_billing"] = carrier.ship_billing
                 vals["ship_account"] = order.shipping_use_carrier_acct
             vals["ship_date_edit"] = fields.Datetime.context_timestamp(
                 self, picking.scheduled_date

--- a/stock_outgoing_shipment_report/models/stock_picking.py
+++ b/stock_outgoing_shipment_report/models/stock_picking.py
@@ -18,14 +18,12 @@ class StockPicking(models.Model):
             product = move.product_id
             vals = {"move_id": move.id}
             if order:
-                carrier = self.carrier_id
+                carrier = order.carrier_id
                 vals["carrier_id"] = carrier.id if carrier else False
                 vals["ship_service_id"] = (
                     order.delivery_carrier_service_id
                     and order.delivery_carrier_service_id.id
                 )
-                vals["ship_carrier"] = carrier.name
-                vals["ship_billing"] = carrier.ship_billing
                 vals["ship_account"] = order.shipping_use_carrier_acct
             vals["ship_date_edit"] = fields.Datetime.context_timestamp(
                 self, picking.scheduled_date

--- a/stock_outgoing_shipment_report/report/stock_outgoing_shipment_report.py
+++ b/stock_outgoing_shipment_report/report/stock_outgoing_shipment_report.py
@@ -27,7 +27,7 @@ class StockOutgoingShipmentReport(models.TransientModel):
     )
     cancel_date_edit = fields.Date("CancelDate (Not For Export)")
     ship_carrier = fields.Char(
-        related="carrier_id.name", string="ShipCarrier", store=True,
+        related="carrier_id.name", string="ShipCarrier",
     )
     ship_service_id = fields.Many2one(
         "delivery.carrier.service", string="ShipService (Not for Export)",
@@ -36,7 +36,9 @@ class StockOutgoingShipmentReport(models.TransientModel):
         related="ship_service_id.name", string="ShipService", store=True,
     )
     ship_account = fields.Char("ShipAccount")
-    ship_billing = fields.Char("ShipBilling")
+    ship_billing = fields.Selection(
+        related="carrier_id.ship_billing", string="ShipBilling", store=True,
+    )
     ship_to_name = fields.Char("ShipToName")
     ship_to_company = fields.Char("ShipToCompany")
     ship_to_address1 = fields.Char("ShipToAddress1")
@@ -69,6 +71,7 @@ class StockOutgoingShipmentReport(models.TransientModel):
 
     @api.constrains(
         "ship_to_name",
+        "ship_account",
         "ship_billing",
         "ship_to_company",
         "ship_to_address1",
@@ -84,6 +87,7 @@ class StockOutgoingShipmentReport(models.TransientModel):
             msg = _("%s should be at most %s digit(s).")
             fields_list = {
                 "ship_to_name": ["ShipToName", 30],
+                "ship_account": ["ShipAccount", 30],
                 "ship_to_company": ["ShipToCompany", 30],
                 "ship_to_address1": ["ShipToAddress1", 30],
                 "ship_to_address2": ["ShipToAddress2", 30],

--- a/stock_outgoing_shipment_report/report/stock_outgoing_shipment_report.py
+++ b/stock_outgoing_shipment_report/report/stock_outgoing_shipment_report.py
@@ -71,8 +71,6 @@ class StockOutgoingShipmentReport(models.TransientModel):
 
     @api.constrains(
         "ship_to_name",
-        "ship_account",
-        "ship_billing",
         "ship_to_company",
         "ship_to_address1",
         "ship_to_address2",
@@ -87,7 +85,6 @@ class StockOutgoingShipmentReport(models.TransientModel):
             msg = _("%s should be at most %s digit(s).")
             fields_list = {
                 "ship_to_name": ["ShipToName", 30],
-                "ship_account": ["ShipAccount", 30],
                 "ship_to_company": ["ShipToCompany", 30],
                 "ship_to_address1": ["ShipToAddress1", 30],
                 "ship_to_address2": ["ShipToAddress2", 30],
@@ -96,7 +93,6 @@ class StockOutgoingShipmentReport(models.TransientModel):
                 "sold_to_address1": ["SoldToAddress1", 30],
                 "sold_to_address2": ["SoldToAddress2", 30],
                 "sold_to_city": ["SoldToCity", 30],
-                "ship_billing": ["ShipBilling", 30],
             }
             for field in fields_list:
                 if rec[field] and len(rec[field]) > fields_list[field][1]:

--- a/stock_outgoing_shipment_report/report/stock_outgoing_shipment_report.py
+++ b/stock_outgoing_shipment_report/report/stock_outgoing_shipment_report.py
@@ -35,9 +35,7 @@ class StockOutgoingShipmentReport(models.TransientModel):
     ship_service = fields.Char(
         related="ship_service_id.name", string="ShipService", store=True,
     )
-    ship_account = fields.Char(
-        "ShipAccount" , related="ship_carrier.name"
-        )
+    ship_account = fields.Char("ShipAccount")
     ship_billing = fields.Char("ShipBilling")
     ship_to_name = fields.Char("ShipToName")
     ship_to_company = fields.Char("ShipToCompany")

--- a/stock_outgoing_shipment_report/report/stock_outgoing_shipment_report.py
+++ b/stock_outgoing_shipment_report/report/stock_outgoing_shipment_report.py
@@ -36,9 +36,7 @@ class StockOutgoingShipmentReport(models.TransientModel):
         related="ship_service_id.name", string="ShipService", store=True,
     )
     ship_account = fields.Char("ShipAccount")
-    ship_billing = fields.Selection(
-        related="carrier_id.ship_billing", string="ShipBilling",
-    )
+    ship_billing = fields.Char(related="carrier_id.ship_billing", string="ShipBilling",)
     ship_to_name = fields.Char("ShipToName")
     ship_to_company = fields.Char("ShipToCompany")
     ship_to_address1 = fields.Char("ShipToAddress1")

--- a/stock_outgoing_shipment_report/report/stock_outgoing_shipment_report.py
+++ b/stock_outgoing_shipment_report/report/stock_outgoing_shipment_report.py
@@ -26,9 +26,7 @@ class StockOutgoingShipmentReport(models.TransientModel):
         string="CancelDate", compute="_compute_date_fields", store=True,
     )
     cancel_date_edit = fields.Date("CancelDate (Not For Export)")
-    ship_carrier = fields.Char(
-        related="carrier_id.name", string="ShipCarrier",
-    )
+    ship_carrier = fields.Char(related="carrier_id.name", string="ShipCarrier",)
     ship_service_id = fields.Many2one(
         "delivery.carrier.service", string="ShipService (Not for Export)",
     )

--- a/stock_outgoing_shipment_report/report/stock_outgoing_shipment_report.py
+++ b/stock_outgoing_shipment_report/report/stock_outgoing_shipment_report.py
@@ -26,7 +26,9 @@ class StockOutgoingShipmentReport(models.TransientModel):
         string="CancelDate", compute="_compute_date_fields", store=True,
     )
     cancel_date_edit = fields.Date("CancelDate (Not For Export)")
-    ship_carrier = fields.Char(related="carrier_id.name", string="ShipCarrier",)
+    ship_carrier = fields.Char(
+        related="carrier_id.name", string="ShipCarrier", store=True,
+    )
     ship_service_id = fields.Many2one(
         "delivery.carrier.service", string="ShipService (Not for Export)",
     )
@@ -35,7 +37,7 @@ class StockOutgoingShipmentReport(models.TransientModel):
     )
     ship_account = fields.Char("ShipAccount")
     ship_billing = fields.Selection(
-        related="carrier_id.ship_billing", string="ShipBilling", store=True,
+        related="carrier_id.ship_billing", string="ShipBilling",
     )
     ship_to_name = fields.Char("ShipToName")
     ship_to_company = fields.Char("ShipToCompany")

--- a/stock_outgoing_shipment_report/report/stock_outgoing_shipment_report.py
+++ b/stock_outgoing_shipment_report/report/stock_outgoing_shipment_report.py
@@ -35,7 +35,9 @@ class StockOutgoingShipmentReport(models.TransientModel):
     ship_service = fields.Char(
         related="ship_service_id.name", string="ShipService", store=True,
     )
-    ship_account = fields.Char("ShipAccount")
+    ship_account = fields.Char(
+        "ShipAccount" , related="ship_carrier.name"
+        )
     ship_billing = fields.Char("ShipBilling")
     ship_to_name = fields.Char("ShipToName")
     ship_to_company = fields.Char("ShipToCompany")

--- a/stock_outgoing_shipment_report/report/stock_outgoing_shipment_report.py
+++ b/stock_outgoing_shipment_report/report/stock_outgoing_shipment_report.py
@@ -71,6 +71,7 @@ class StockOutgoingShipmentReport(models.TransientModel):
 
     @api.constrains(
         "ship_to_name",
+        "ship_billing",
         "ship_to_company",
         "ship_to_address1",
         "ship_to_address2",
@@ -93,6 +94,7 @@ class StockOutgoingShipmentReport(models.TransientModel):
                 "sold_to_address1": ["SoldToAddress1", 30],
                 "sold_to_address2": ["SoldToAddress2", 30],
                 "sold_to_city": ["SoldToCity", 30],
+                "ship_billing": ["ShipBilling", 30],
             }
             for field in fields_list:
                 if rec[field] and len(rec[field]) > fields_list[field][1]:

--- a/stock_outgoing_shipment_report/views/delivery_carrier_views.xml
+++ b/stock_outgoing_shipment_report/views/delivery_carrier_views.xml
@@ -7,6 +7,7 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='company_id']" position="after">
                 <field name="delivery_carrier_service_ids" widget="many2many_tags" />
+                <field name="ship_billing" />
             </xpath>
         </field>
     </record>

--- a/stock_outgoing_shipment_report/views/stock_outgoing_shipment_report_views.xml
+++ b/stock_outgoing_shipment_report/views/stock_outgoing_shipment_report_views.xml
@@ -8,13 +8,13 @@
                 <field name="reference_number" />
                 <field name="purchase_order_number" />
                 <field name="ship_date" invisible="1" />
-                <field name="ship_date_edit" widget="date" string="ShipDate" />
+                <field name="ship_date_edit" widget="date" string="ShipDate" invisible="1" />
                 <field name="cancel_date" invisible="1" />
-                <field name="cancel_date_edit" widget="date" string="CancelDate" />
+                <field name="cancel_date_edit" widget="date" string="CancelDate" invisible="1" />
                 <field name="ship_carrier" />
                 <field name="ship_service" />
                 <field name="ship_account" />
-                <field name="ship_billing" />
+                <field name="ship_billing" invisible="1" />
                 <field name="ship_to_name" />
                 <field name="ship_to_company" />
                 <field name="ship_to_address1" required="True" />

--- a/stock_outgoing_shipment_report/views/stock_outgoing_shipment_report_views.xml
+++ b/stock_outgoing_shipment_report/views/stock_outgoing_shipment_report_views.xml
@@ -22,9 +22,9 @@
                     invisible="1"
                 />
                 <field name="ship_carrier" />
+                <field name="ship_billing" invisible="1" />
                 <field name="ship_service" />
                 <field name="ship_account" />
-                <field name="ship_billing" invisible="1" />
                 <field name="ship_to_name" />
                 <field name="ship_to_company" />
                 <field name="ship_to_address1" required="True" />

--- a/stock_outgoing_shipment_report/views/stock_outgoing_shipment_report_views.xml
+++ b/stock_outgoing_shipment_report/views/stock_outgoing_shipment_report_views.xml
@@ -8,9 +8,19 @@
                 <field name="reference_number" />
                 <field name="purchase_order_number" />
                 <field name="ship_date" invisible="1" />
-                <field name="ship_date_edit" widget="date" string="ShipDate" invisible="1" />
+                <field
+                    name="ship_date_edit"
+                    widget="date"
+                    string="ShipDate"
+                    invisible="1"
+                />
                 <field name="cancel_date" invisible="1" />
-                <field name="cancel_date_edit" widget="date" string="CancelDate" invisible="1" />
+                <field
+                    name="cancel_date_edit"
+                    widget="date"
+                    string="CancelDate"
+                    invisible="1"
+                />
                 <field name="ship_carrier" />
                 <field name="ship_service" />
                 <field name="ship_account" />

--- a/stock_outgoing_shipment_report/views/stock_outgoing_shipment_report_views.xml
+++ b/stock_outgoing_shipment_report/views/stock_outgoing_shipment_report_views.xml
@@ -22,8 +22,8 @@
                     invisible="1"
                 />
                 <field name="ship_carrier" />
-                <field name="ship_billing" invisible="1" />
                 <field name="ship_service" />
+                <field name="ship_billing" invisible="1" />
                 <field name="ship_account" />
                 <field name="ship_to_name" />
                 <field name="ship_to_company" />

--- a/stock_outgoing_shipment_report/views/stock_outgoing_shipment_report_views.xml
+++ b/stock_outgoing_shipment_report/views/stock_outgoing_shipment_report_views.xml
@@ -13,6 +13,7 @@
                 <field name="cancel_date_edit" widget="date" string="CancelDate" />
                 <field name="ship_carrier" />
                 <field name="ship_service" />
+                <field name="ship_account" />
                 <field name="ship_billing" />
                 <field name="ship_to_name" />
                 <field name="ship_to_company" />


### PR DESCRIPTION
[1779](https://www.quartile.co/web#id=1779&action=771&model=project.task&view_type=form&menu_id=505)

検証内容：
**「Inventory > My Company: Delivery Orders」**にて、
**「Action > Generate Delivery Data」**を押して検証。

**1.ShipBillingフィールド**
新たにdelivery_carrierモデルにSelection型の同名カラムを追加。
delivery_carrierの同名カラムにデータが存在する場合、文字列として出力することを確認

**2.Ship Accountフィールド**
参照しているSale Order内の Delivery Carrier Account Number の値を参照することを確認

**3.フィールドの非表示**
ShipDate, CancelDate, ShipBillingフィールドはinvisible ="1" のオプションを付けて非表示。
invisibleを削除した場合にデータを表示することを確認。